### PR TITLE
（GPT-4.1）Cloud Run/Cloud Build対応: 自動デプロイ用cloudbuild.yaml追加・README整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+## ローカル開発環境の起動方法
+
+1. 環境変数ファイルをコピー
+
+```sh
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+
+2. Docker Composeで起動
+
+```sh
+docker-compose up --build
+```
+
+- フロントエンド: http://localhost:3000
+- バックエンド: http://localhost:3001
+- DB: localhost:5432（開発用PostgreSQL）
+
+## Google Cloudデプロイ補足
+
+- 本番DBはCloud SQL(PostgreSQL)を利用し、`db`サービスは不要です。
+- Cloud Run用には各サービスのDockerfileをそのまま利用できます。
+- Railsの`DATABASE_URL`はCloud SQL接続情報に書き換えてください。
+- master.key等のシークレットはGoogle Secret Manager等で管理してください。
+
+## Google Cloud Build/Run での自動デプロイ手順
+
+1. 必要なGoogle Cloudリソースを作成
+   - Artifact Registry（Docker用リポジトリ）
+   - Cloud SQL（PostgreSQL）
+   - Secret Manager（RAILS_MASTER_KEY等）
+   - Cloud Run（サービスは自動作成されます）
+
+2. cloudbuild.yaml の変数を編集
+   - プロジェクトID、リージョン、リポジトリ名、Cloud SQL接続名など
+
+3. Cloud Buildトリガーを作成
+   - GCPコンソール「Cloud Build」→「トリガー」→「新しいトリガー」
+   - リポジトリとブランチ、cloudbuild.yamlを指定
+   - 必要に応じてサービスアカウント権限を付与
+
+4. pushやPRで自動ビルド・デプロイ
+
+### 注意点
+- Artifact Registryのリポジトリは事前に作成してください
+- Cloud SQLのユーザー名・パスワード・DB名はSecret Managerや環境変数で安全に管理してください
+- RAILS_MASTER_KEYはSecret Managerで管理し、Cloud Runのデプロイ時に`--set-secrets`で渡します
+- Cloud SQLの接続は`--add-cloudsql-instances`でCloud Runに紐付けます
+- backend, frontendともDockerfileはそのまま利用できます
+
+### 参考: cloudbuild.yaml
+詳しくは`cloudbuild.yaml`を参照してください 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,52 @@
+substitutions:
+  _REGION: asia-northeast1
+  _PROJECT_ID: your-gcp-project-id
+  _REPO: opcha-repo
+  _BACKEND_SERVICE: opcha-backend
+  _FRONTEND_SERVICE: opcha-frontend
+  _CLOUDSQL_INSTANCE: your-cloudsql-instance-connection-name
+steps:
+  # backend build & push
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'build', '-t', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/backend:latest', './backend' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'push', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/backend:latest' ]
+
+  # frontend build & push
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'build', '-t', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/frontend:latest', './frontend' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'push', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/frontend:latest' ]
+
+  # deploy backend to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - ${_BACKEND_SERVICE}
+      - --image=${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/backend:latest
+      - --region=${_REGION}
+      - --platform=managed
+      - --allow-unauthenticated
+      - --add-cloudsql-instances=${_CLOUDSQL_INSTANCE}
+      - --set-secrets=RAILS_MASTER_KEY=projects/${_PROJECT_ID}/secrets/RAILS_MASTER_KEY:latest
+      - --set-env-vars=DATABASE_URL=postgresql://<USER>:<PASSWORD>@/<DBNAME>?host=/cloudsql/${_CLOUDSQL_INSTANCE}
+
+  # deploy frontend to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - ${_FRONTEND_SERVICE}
+      - --image=${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/frontend:latest
+      - --region=${_REGION}
+      - --platform=managed
+      - --allow-unauthenticated
+      - --set-env-vars=NEXT_PUBLIC_API_URL=https://<backend-service-url>
+
+# 備考:
+# - 必要に応じてsubstitutionsの値を変更してください
+# - Secret ManagerやCloud SQLの設定はgcloudコマンドの引数で指定しています
+# - Artifact Registryのリポジトリ（${_REPO}）は事前に作成しておいてください 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: opcha_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  backend:
+    build: ./backend
+    env_file:
+      - ./backend/.env
+    environment:
+      DATABASE_URL: postgres://postgres:password@db:5432/opcha_dev
+    ports:
+      - "3001:3000"
+    depends_on:
+      - db
+    volumes:
+      - ./backend:/rails
+  frontend:
+    build: ./frontend
+    env_file:
+      - ./frontend/.env
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+    volumes:
+      - ./frontend:/app
+volumes:
+  db-data:
+# 本番環境ではCloud SQL(PostgreSQL)を利用し、dbサービスは不要 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+out
+build
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.env*
+.DS_Store 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+FROM node:20-slim AS base
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "start"] 


### PR DESCRIPTION
### 概要
Google Cloud Run/Cloud Buildによる自動デプロイ対応を行いました。

### 主な変更点
- `cloudbuild.yaml` を新規追加
  - backend（Rails）/frontend（Next.js）のDockerイメージをビルド＆Artifact Registryにpush
  - Cloud Runへ自動デプロイ（Cloud SQL/Secret Manager連携例もコメント記載）
- `README.md` にGoogle Cloud Build/Run自動デプロイ手順・注意点を追記
- `docker-compose.yml`/Dockerfileは既存のまま利用可能

### デプロイ手順（概要）
1. GCPでArtifact Registry・Cloud SQL・Secret Managerを作成
2. `cloudbuild.yaml`の変数を自分の環境に合わせて編集
3. Cloud Buildトリガーを作成し、pushやPRで自動デプロイ

### 補足
- Secret ManagerやCloud SQLの接続情報はREADME・cloudbuild.yamlのコメントを参照してください
- ご不明点や追加要望があればご指摘ください

ご確認よろしくお願いいたします。