### PR TITLE
CORS設定の有効化

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -5,12 +5,17 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    if Rails.env.development?
+      origins "localhost:3000", "127.0.0.1:3000"
+    else
+      origins ENV["FRONTEND_DOMAIN"] || "https://your-production-domain.com"
+    end
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
+  end
+end


### PR DESCRIPTION
## Summary
- バックエンドのCORS設定をコメントアウト状態から有効化
- 開発環境用に`localhost:3000`と`127.0.0.1:3000`からのアクセス許可
- 本番環境用に環境変数`FRONTEND_DOMAIN`で設定可能なドメイン制限
- セッション認証対応のため`credentials: true`設定を追加

## Test plan
- [ ] 開発環境でフロントエンドからのAPI通信が正常に動作することを確認
- [ ] プリフライトリクエスト(OPTIONS)が正常に処理されることを確認
- [ ] セッション認証が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)